### PR TITLE
don't execute in civimobile context

### DIFF
--- a/noverwrite.php
+++ b/noverwrite.php
@@ -7,6 +7,13 @@ function noverwrite_civicrm_buildForm ( $formName, &$form ){
 
   if (!in_array ($formName, $names))
     return;
+
+  // Don't invoke if we're using CiviMobile, since CiviMobile depends on users being able
+  // to edit records via profiles.
+  $path = CRM_Utils_Array::value('HTTP_REFERER', $_SERVER);
+  if($formName == 'CRM_Profile_Form_Edit' && preg_match('#civicrm/mobile#', $path)) {
+    return;
+  }
   $session = CRM_Core_Session::singleton();
   if (!$session->get('userID') && !array_key_exists("cs",$_GET)) {
     return; // anonymous user, nothing to bloc


### PR DESCRIPTION
Civimobile depends on users editing other users contact info
using a profile.
