### PR TITLE
Disable also fields with no value

### DIFF
--- a/noverwrite.php
+++ b/noverwrite.php
@@ -30,7 +30,7 @@ function noverwrite_civicrm_buildForm ( $formName, &$form ){
       continue;
     }
     $field=$form->getElement($f);
-    if ($field && $field->_attributes["value"])
+    if ($field)
       $form->freeze( $f );
   }
   // if you want to bloc it at the js level only, uncomment the next line and comment out the freeze


### PR DESCRIPTION
Since the middle name is sometimes populated and sometimes not, but in the form we do not want people to change it, we needed to change this. 
This PR will change the behavior so that fields with or without a value will be disabled.