### PR TITLE
buildForm: add CRM_Contact_Form_RelatedContact

### DIFF
--- a/noverwrite.php
+++ b/noverwrite.php
@@ -2,11 +2,12 @@
 
 require_once 'noverwrite.civix.php';
 
-function noverwrite_civicrm_buildForm ( $formName, &$form ){
-  $names = array ("CRM_Profile_Form_Edit","CRM_Event_Form_Registration_Register","CRM_Contribute_Form_Contribution_Main");
+function noverwrite_civicrm_buildForm($formName, &$form) {
+  $names = ['CRM_Profile_Form_Edit','CRM_Event_Form_Registration_Register','CRM_Contribute_Form_Contribution_Main','CRM_Contact_Form_RelatedContact'];
 
-  if (!in_array ($formName, $names))
+  if (!in_array($formName, $names)) {
     return;
+  }
 
   // Don't invoke if we're using CiviMobile, since CiviMobile depends on users being able
   // to edit records via profiles.


### PR DESCRIPTION
I stumbled on the `CRM_Contact_Form_RelatedContact` form, which is linked from the Contact Dashboard, when they have permission to "edit my contact.

It's a very weird form, but it seems to work:

![image](https://github.com/TechToThePeople/noverwrite/assets/254741/909fccdf-500e-4397-82bb-5b8c3d4811e7)

The PR includes very minor syntax cleanup around the line changed.