### PR TITLE
Fix deprecation in preg_match when $path is NULL

### DIFF
--- a/noverwrite.php
+++ b/noverwrite.php
@@ -11,7 +11,7 @@ function noverwrite_civicrm_buildForm($formName, &$form) {
 
   // Don't invoke if we're using CiviMobile, since CiviMobile depends on users being able
   // to edit records via profiles.
-  $path = CRM_Utils_Array::value('HTTP_REFERER', $_SERVER);
+  $path = CRM_Utils_Array::value('HTTP_REFERER', $_SERVER, "");
   if($formName == 'CRM_Profile_Form_Edit' && preg_match('#civicrm/mobile#', $path)) {
     return;
   }


### PR DESCRIPTION
By default CRM_Utils_Array will return NULL if the key doesn't exist. Passing NULL to parameter 2 of preg_match is now deprecated behavior:

```
Got error 'PHP message: PHP Deprecated:  preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in /srv/www/SITE/public_html/wp-content/uploads/civicrm/ext/eu.tttp.noverwrite/noverwrite.php on line 15'
```

If the user goes directly to the profile edit form and there's no HTTP_REFERER, this change sets the value of $path to an empty string, which resolves the deprecation warning.