### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/noverwrite.php
+++ b/noverwrite.php
@@ -11,7 +11,7 @@ function noverwrite_civicrm_buildForm($formName, &$form) {
 
   // Don't invoke if we're using CiviMobile, since CiviMobile depends on users being able
   // to edit records via profiles.
-  $path = CRM_Utils_Array::value('HTTP_REFERER', $_SERVER);
+  $path = $_SERVER['HTTP_REFERER'] ?? NULL;
   if($formName == 'CRM_Profile_Form_Edit' && preg_match('#civicrm/mobile#', $path)) {
     return;
   }


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.